### PR TITLE
[Modify] Repeated 'Cardiology' specification corrected

### DIFF
--- a/client/src/pages/doctor/auth/page.jsx
+++ b/client/src/pages/doctor/auth/page.jsx
@@ -216,7 +216,6 @@ const RegisterComponent = ({ setIsLogin }) => {
                 
               </option>
               <option value="Cardiology">Cardiology</option>
-              <option value="Cardiology">Cardiology</option>
               <option value="Neurology">Neurology</option>
               <option value="Pediatrics">Pediatrics</option>
               <option value="Orthopedics">Orthopedics</option>


### PR DESCRIPTION
I encountered an error in the `client\src\pages\doctor\auth\page.jsx` file. The specific issue is as follows:

**Error**
```
lineNumber: 218 & 219; 'Cardiology' need to be present only one time but provided two times causing repetition in the Doctor Registration form 
```

#### Resolution:
Modify it to be present only 1 time in the Doctor Registration form maintaining the standards of the website


This fix resolves the issue and adheres to proper formatting of the Registration form

---

@joefelx  please assign this to me under swoc

---